### PR TITLE
Fix multi-letter emoji hints not working and make lowercase the default

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
             "properties": {
                 "talon-filetree.letterStyling": {
                     "type": "string",
-                    "default": "emoji",
+                    "default": "lowercase",
                     "enum": [
-                        "emoji",
                         "lowercase",
-                        "uppercase"
+                        "uppercase",
+                        "emoji"
                     ]
                 }
             }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,10 @@ updateLetterStyling();
 export function getDecoratedHint(hint: string) {
     switch (letterStyling) {
         case "emoji":
-            return letterToEmojiMap.get(hint);
+            return hint
+                .split("")
+                .map((char) => letterToEmojiMap.get(char))
+                .join("");
 
         case "uppercase":
             return hint.toUpperCase();


### PR DESCRIPTION
I think letters are easier to read than emoji letters.

This fixes #22