### PR TITLE
Add settings to place the hints to the left and select separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.2 [2023-06-21]
+
+- fix bug where emoji letters wouldn't show beyond 26 items (thanks to [PR](https://github.com/paul-schaaf/talon-filetree/pull/23) by [david-tejada](https://github.com/david-tejada))
+- hints are now lowercase letters by default (thanks to [PR](https://github.com/paul-schaaf/talon-filetree/pull/23) by [david-tejada](https://github.com/david-tejada)) 
+
 ## 0.6.1 [2023-06-11]
 
 All changes in this release thanks to PRs by [david-tejada](https://github.com/david-tejada)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Creates a new file tree view that can be used with voice commands.
 
 ### Extension Settings
 
-- Hints are displayed as emojis to differentiate them from file names. This can be changed in the settings.
+- `talon-filetree.letterStyling`: Select the style of the hints between `lowercase`, `uppercase` or `emoji`.
+- `talon-filetree.hintPosition`: You can select to place the hints to the left or the right of the file name.
+- `talon-filetree.hintSeparator`: Select the symbols to separate the hint from the file name (only applies when hints are positioned to the left).
 
 ### Other Settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
     "name": "talon-filetree",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "talon-filetree",
-            "version": "0.6.0",
+            "version": "0.6.1",
             "dependencies": {
+                "assert-never": "^1.2.1",
                 "lodash": "^4.17.21",
                 "minimatch": "^9.0.1",
                 "simple-git": "^3.17.0"
@@ -548,6 +549,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/assert-never": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+            "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,33 @@
                         "lowercase",
                         "uppercase"
                     ]
+                },
+                "talon-filetree.hintPosition": {
+                    "type": "string",
+                    "default": "right",
+                    "enum": [
+                        "left",
+                        "right"
+                    ]
+                },
+                "talon-filetree.hintSeparator": {
+                    "type": "string",
+                    "default": "brackets",
+                    "description": "Characters to separate the hint from the file or folder name (only applies when hints are positioned to the left)",
+                    "enum": [
+                        "brackets",
+                        "pipe",
+                        "hyphen",
+                        "colon",
+                        "spaces"
+                    ],
+                    "enumDescriptions": [
+                        "[a] file.ext",
+                        "a | file.ext",
+                        "a - file.ext",
+                        "a: file.text",
+                        "a file.text"
+                    ]
                 }
             }
         },
@@ -133,6 +160,7 @@
         "sleistner.vscode-fileutils"
     ],
     "dependencies": {
+        "assert-never": "^1.2.1",
         "lodash": "^4.17.21",
         "minimatch": "^9.0.1",
         "simple-git": "^3.17.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "talon-filetree",
     "publisher": "PaulSchaaf",
     "description": "An extension for navigating and manipulating the file tree quickly by voice",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/paul-schaaf/talon-filetree"

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
             "properties": {
                 "talon-filetree.letterStyling": {
                     "type": "string",
-                    "default": "emoji",
+                    "default": "lowercase",
                     "enum": [
-                        "emoji",
                         "lowercase",
-                        "uppercase"
+                        "uppercase",
+                        "emoji"
                     ]
                 },
                 "talon-filetree.hintPosition": {

--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -8,10 +8,10 @@ import {
     getGitIgnored
 } from "./fileUtils";
 import {
-    getDecoratedHint,
+    getDescriptionAndLabel,
     sleep,
     traverseTree,
-    updateLetterStyling
+    updateHintSettings
 } from "./utils";
 import { minimatch } from "minimatch";
 
@@ -399,8 +399,14 @@ class Entry extends vscode.TreeItem {
     ) {
         super(resourceUri, collapsibleState);
         if (hint) {
-            this.description = getDecoratedHint(hint);
+            const { label, description } = getDescriptionAndLabel(
+                resourceUri,
+                hint
+            );
+            this.description = description;
+            this.label = label;
         }
+
         this.resourceUri = resourceUri;
         this.type = type;
         this.parent = parent;
@@ -462,9 +468,13 @@ export class FileExplorer {
         context.subscriptions.push(
             vscode.workspace.onDidChangeConfiguration((event) => {
                 if (
-                    event.affectsConfiguration("talon-filetree.letterStyling")
+                    event.affectsConfiguration(
+                        "talon-filetree.letterStyling"
+                    ) ||
+                    event.affectsConfiguration("talon-filetree.hintPosition") ||
+                    event.affectsConfiguration("talon-filetree.hintSeparator")
                 ) {
-                    updateLetterStyling();
+                    updateHintSettings();
                     this.treeDataProvider.hintRefresh();
                 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,7 +57,10 @@ updateHintSettings();
 function getDecoratedHint(hint: string) {
     switch (letterStyling) {
         case "emoji":
-            return letterToEmojiMap.get(hint);
+            return hint
+                .split("")
+                .map((char) => letterToEmojiMap.get(char))
+                .join("");
 
         case "uppercase":
             return hint.toUpperCase();


### PR DESCRIPTION
This PR adds the ability to place the hints to the left of the file name to avoid the hint being hidden when there is not enough space as discussed in issue #27.

It also adds a setting to decide how to separate the hint from the filename when the hint is placed to the left.