### PR TITLE
Optimize create command

### DIFF
--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -164,7 +164,7 @@ export class FileDataProvider implements vscode.TreeDataProvider<Entry> {
         return this.pathEntryMap.get(path);
     }
 
-    async getEntryFromHint(hint: string) {
+    getEntryFromHint(hint: string) {
         const entry = this.hintEntryMap.get(hint);
         if (!entry) {
             throw new Error(`No entry for hint '${hint}'`);
@@ -697,7 +697,7 @@ export class FileExplorer {
     }
 
     private async toggleDirectoryOrOpenFile(hint: string) {
-        const entry = await this.treeDataProvider.getEntryFromHint(hint);
+        const entry = this.treeDataProvider.getEntryFromHint(hint);
 
         if (!entry.isFolder) {
             await vscode.commands.executeCommand(
@@ -715,7 +715,7 @@ export class FileExplorer {
     }
 
     private async closeParentDirectory(hint: string) {
-        const entry = await this.treeDataProvider.getEntryFromHint(hint);
+        const entry = this.treeDataProvider.getEntryFromHint(hint);
 
         if (entry.parent) {
             await this.collapseEntry(entry.parent);
@@ -723,7 +723,7 @@ export class FileExplorer {
     }
 
     private async expandDirectory(hint: string, level: number) {
-        const entry = await this.treeDataProvider.getEntryFromHint(hint);
+        const entry = this.treeDataProvider.getEntryFromHint(hint);
         this.treeDataProvider.preExpandToLevel(entry, level);
 
         if (level === 0) {
@@ -746,7 +746,7 @@ export class FileExplorer {
 
     private async collapseRoot() {
         // We need to get any entry to be able to use "list.collapseAll"
-        const entry = await this.treeDataProvider.getEntryFromHint("a");
+        const entry = this.treeDataProvider.getEntryFromHint("a");
 
         if (entry) {
             await this.treeView.reveal(entry, { focus: true });
@@ -760,7 +760,7 @@ export class FileExplorer {
     }
 
     private async openFile(hint: string) {
-        const entry = await this.treeDataProvider.getEntryFromHint(hint);
+        const entry = this.treeDataProvider.getEntryFromHint(hint);
 
         if (entry.isFolder) {
             await this.treeView.reveal(entry, { expand: true });
@@ -771,7 +771,7 @@ export class FileExplorer {
     }
 
     private async renameFile(hint: string) {
-        const entry = await this.treeDataProvider.getEntryFromHint(hint);
+        const entry = this.treeDataProvider.getEntryFromHint(hint);
         await this.treeView.reveal(entry);
 
         await vscode.commands.executeCommand(
@@ -833,7 +833,7 @@ export class FileExplorer {
     }
 
     private async createFile(hint: string) {
-        const entry = await this.treeDataProvider.getEntryFromHint(hint);
+        const entry = this.treeDataProvider.getEntryFromHint(hint);
 
         const directoryUri = entry.isFolder
             ? entry.resourceUri
@@ -877,12 +877,12 @@ export class FileExplorer {
     }
 
     private async select(hint: string) {
-        const entry = await this.treeDataProvider.getEntryFromHint(hint);
+        const entry = this.treeDataProvider.getEntryFromHint(hint);
         await this.treeView.reveal(entry, { focus: true });
     }
 
     private async deleteFile(hint: string): Promise<void> {
-        const entry = await this.treeDataProvider.getEntryFromHint(hint);
+        const entry = this.treeDataProvider.getEntryFromHint(hint);
         await this.treeView.reveal(entry);
 
         const selection = await vscode.window.showInformationMessage(


### PR DESCRIPTION
this pr:
- speeds up the create command by removing a timeout that I think is unnecessary for the create command
-> there is now a getEntryFromPathWithRetry function which is the function with the timeout and a sync getEntryFromPath function without the timeout that is used by the createFile function
- removes some unnecessary async/await statements
