### PR TITLE
Fix-create-file-delay

### DIFF
--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -137,7 +137,7 @@ export class FileDataProvider implements vscode.TreeDataProvider<Entry> {
             const entry = this.pathEntryMap.get(path);
 
             if (entry) {
-                resolve(entry);
+                return resolve(entry);
             }
 
             // If the entry is not available, resolve right away in cases when
@@ -152,7 +152,7 @@ export class FileDataProvider implements vscode.TreeDataProvider<Entry> {
                 (workspaceFolder.uri.fsPath === path &&
                     workspaceFolders?.length === 1)
             ) {
-                resolve(undefined);
+                return resolve(undefined);
             }
 
             // For all other cases poll every 20ms until the entry is ready with

--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -133,6 +133,21 @@ export class FileDataProvider implements vscode.TreeDataProvider<Entry> {
 
     async getEntryFromPath(path: string): Promise<Entry | undefined> {
         return new Promise((resolve) => {
+            const workspaceFolder = vscode.workspace.getWorkspaceFolder(
+                vscode.Uri.file(path)
+            );
+            const workspaceFolders = vscode.workspace.workspaceFolders;
+
+            // Resolve right away in cases when we know there won't be an entry
+            // for the given path.
+            if (
+                !workspaceFolder ||
+                (workspaceFolder.uri.fsPath === path &&
+                    workspaceFolders?.length === 1)
+            ) {
+                resolve(undefined);
+            }
+
             let timedOut = false;
 
             const timeout = setTimeout(() => {

--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -827,15 +827,16 @@ export class FileExplorer {
     private async createFile(hint: string) {
         const entry = await this.treeDataProvider.getEntryFromHint(hint);
 
-        const directoryUri = entry.isFolder
-            ? entry.resourceUri
-            : vscode.Uri.file(path.dirname(entry.resourceUri.fsPath));
+        const directoryEntry = entry.isFolder ? entry : entry.parent;
+        const directoryUri =
+            directoryEntry?.resourceUri ??
+            vscode.workspace.getWorkspaceFolder(entry.resourceUri)!.uri;
 
-        const directoryEntry = await this.treeDataProvider.getEntryFromPath(
-            directoryUri.fsPath
-        );
         if (directoryEntry) {
             await this.treeView.reveal(directoryEntry);
+        } else {
+            // Select the target entry since there is no parent folder to select
+            await this.treeView.reveal(entry, { select: true, focus: false });
         }
 
         const filename = await vscode.window.showInputBox({


### PR DESCRIPTION
This pull request handles a delay when creating a file or folder in the project root. First I remove the need to use `getEntryFromPath` in `createFile`, which solves the delay problem. Then in `getEntryFromPath` I resolve with undefined right away when we know that path won't ever have an entry. This will prevent similar bugs in the future.