### PR TITLE
Use-workspace-edit

### DIFF
--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -830,13 +830,13 @@ export class FileExplorer {
         }
 
         if (await exists(newUri)) {
-            const replace = await vscode.window.showInformationMessage(
+            const confirmation = await vscode.window.showInformationMessage(
                 `A file or folder with the name '${fileName}' already exists in the destination folder. Do you want to replace it?`,
                 { modal: true, detail: "This action is irreversible!" },
                 "Replace"
             );
 
-            if (!replace) {
+            if (!confirmation) {
                 return;
             }
         }


### PR DESCRIPTION
This pull request fixes some buggy behavior when moving files with open editors. For example, if you move a file that has unsaved changes it will prompt you to save those changes, after confirmation you will end up with two files, one in the destination without the changes and one in the source with those changes. Apart from that, undo/redo is not available after moving the file.

Changes:

- Fix buggy behavior when moving files with unsaved changes.
- Make undo/redo of edits possible after moving files with open editors.
- Make undo/redo of file moves possible.
- Show confirmation modal when target file/folder exists. Behaving the same as the native explorer.