### PR TITLE
Fix unnecessary or wrong selection of current file

### DIFF
--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -449,7 +449,7 @@ export class FileExplorer {
 
     private autoReveal: boolean;
     private autoRevealExcludeGlobPatterns = <string[]>[];
-    private lastActiveWorkspaceFileUri?: vscode.Uri;
+    private lastActiveWorkspaceFilePath?: string;
 
     constructor(context: vscode.ExtensionContext) {
         this.treeDataProvider = new FileDataProvider(context);
@@ -621,8 +621,8 @@ export class FileExplorer {
             return;
         }
 
-        if (uri !== this.lastActiveWorkspaceFileUri) {
-            this.lastActiveWorkspaceFileUri = uri;
+        if (uri.fsPath !== this.lastActiveWorkspaceFilePath) {
+            this.lastActiveWorkspaceFilePath = uri.fsPath;
             await this.revealFile(uri, false, true);
         }
     }

--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -688,7 +688,7 @@ export class FileExplorer {
             const entry = await this.treeDataProvider.getEntryFromPath(
                 directory
             );
-            if (entry) {
+            if (entry && entry.collapsibleState === 1) {
                 await this.treeView.reveal(entry, { select: false, expand: 1 });
             }
         }

--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -449,13 +449,7 @@ export class FileExplorer {
 
     private autoReveal: boolean;
     private autoRevealExcludeGlobPatterns = <string[]>[];
-
-    /**
-     * The `uri` of the active tab of the active group if the file belongs to
-     * the current workspace. Otherwise, the last file that was active in the
-     * current workspace.
-     * */
-    private workspaceActiveFileUri?: vscode.Uri;
+    private lastActiveWorkspaceFileUri?: vscode.Uri;
 
     constructor(context: vscode.ExtensionContext) {
         this.treeDataProvider = new FileDataProvider(context);
@@ -627,8 +621,8 @@ export class FileExplorer {
             return;
         }
 
-        if (uri !== this.workspaceActiveFileUri) {
-            this.workspaceActiveFileUri = uri;
+        if (uri !== this.lastActiveWorkspaceFileUri) {
+            this.lastActiveWorkspaceFileUri = uri;
             await this.revealFile(uri, false, true);
         }
     }

--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -688,7 +688,7 @@ export class FileExplorer {
             const entry = await this.treeDataProvider.getEntryFromPath(
                 directory
             );
-            if (entry && entry.collapsibleState === 1) {
+            if (entry) {
                 await this.treeView.reveal(entry, { select: false, expand: 1 });
             }
         }

--- a/src/fileUtils.ts
+++ b/src/fileUtils.ts
@@ -47,26 +47,3 @@ export async function getGitIgnored(root: string, paths: string[]) {
         return [];
     }
 }
-
-export function getActiveTabUri() {
-    // Using this instead of vscode.window.activeTextEditor so that it works
-    // with files that are not text, like images
-    const input = vscode.window.tabGroups.activeTabGroup.activeTab?.input as
-        | { uri?: vscode.Uri }
-        | { modified?: vscode.Uri }
-        | undefined;
-
-    if (!input) {
-        return undefined;
-    }
-
-    if ("uri" in input) {
-        return input.uri;
-    }
-
-    if ("modified" in input) {
-        return input.modified;
-    }
-
-    return undefined;
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,3 +129,21 @@ export function traverseTree<T extends { children?: T[] }>(
         }
     }
 }
+
+export function getTabUri(tab: vscode.Tab) {
+    const input = tab.input;
+    if (
+        input instanceof vscode.TabInputText ||
+        input instanceof vscode.TabInputCustom ||
+        input instanceof vscode.TabInputNotebook
+    ) {
+        return input.uri;
+    }
+
+    if (
+        input instanceof vscode.TabInputTextDiff ||
+        input instanceof vscode.TabInputNotebookDiff
+    ) {
+        return input.modified;
+    }
+}


### PR DESCRIPTION
This PR fixes unnecessary auto reveals (selection) of the active file in the tree view. It also fixes some occurrences of the wrong file being auto revealed in the tree view.

The problem here is that I had assumed that the `onDidChangeTabs` and `onDidChangeTabGroups` triggered only when the active tab or active tab group changed. In reality there are several things that trigger these events: opening tabs, removing tabs, a change in the isDirty status of the file,... Anytime any property of the tab changes the `onDidChangeTabs` will get triggered.

The fix involves keeping track of the current active file in the workspace and checking if the active file has changed. There is `vscode.window.onDidChangeActiveTextEditor` but I can't use it because it doesn't work when the file is not a text file, like an image, a binary or similar.