### PR TITLE
Fix stutter when revealing files

### DIFF
--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -274,7 +274,11 @@ export class FileDataProvider implements vscode.TreeDataProvider<Entry> {
     addFoldersToExpand(folders: string[]) {
         for (const folder of folders) {
             const entry = this.pathEntryMap.get(folder);
-            if (!entry || entry.collapsibleState === 1) {
+            if (
+                !entry ||
+                entry.collapsibleState ===
+                    vscode.TreeItemCollapsibleState.Collapsed
+            ) {
                 this.foldersToExpand.add(folder);
             }
         }
@@ -671,7 +675,10 @@ export class FileExplorer {
                 directory
             );
 
-            if (entry?.collapsibleState === 1) {
+            if (
+                entry?.collapsibleState ===
+                vscode.TreeItemCollapsibleState.Collapsed
+            ) {
                 return this.treeView.reveal(entry, {
                     select: false,
                     expand: 1

--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -218,6 +218,7 @@ export class FileDataProvider implements vscode.TreeDataProvider<Entry> {
     // keep track of the element's collapsible state
     entryWasExpanded(entry: Entry) {
         entry.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+        this.foldersToExpand.delete(entry.resourceUri.fsPath);
     }
 
     async entryWasCollapsed(entry: Entry) {


### PR DESCRIPTION
This PR fixes a stutter when revealing files. This was most noticeable when revealing deeply nested files and when the tree view scrolls. The problem was that we were calling `reveal` on every ancestor, no matter if this was already expanded or not, causing it to show every ancestor folder, jumping up and down if necessary. This also prevents a waterfall effect that happened as the ancestor folders were expanded one after the other.