### PR TITLE
Implement `Find in Folder...` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Creates a new file tree view that can be used with voice commands.
 - Create files
 - Delete files
 - Select files (useful for scrolling through file tree using keys and centering files in tree view)
+- Finding files in folder
 
 ## Settings
 

--- a/src/fileExplorer.ts
+++ b/src/fileExplorer.ts
@@ -625,6 +625,11 @@ export class FileExplorer {
             async () =>
                 this.showMessageIfError(async () => this.focusCurrentFile())
         );
+        vscode.commands.registerCommand(
+            "talon-filetree.findInFolder",
+            async (hint: string) =>
+                this.showMessageIfError(async () => this.findInFolder(hint))
+        );
     }
 
     private async handleActiveTabChange(activeTab: vscode.Tab) {
@@ -761,6 +766,22 @@ export class FileExplorer {
         }
 
         await this.revealFile(uri, true);
+    }
+
+    private async findInFolder(hint: string) {
+        const entry = this.treeDataProvider.getEntryFromHint(hint);
+
+        const folderEntry = entry.isFolder ? entry : entry.parent;
+        const folderUri =
+            folderEntry?.resourceUri ??
+            vscode.workspace.getWorkspaceFolder(entry.resourceUri)!.uri;
+
+        await this.treeView.reveal(folderEntry ?? entry);
+
+        await vscode.commands.executeCommand(
+            "filesExplorer.findInFolder",
+            folderUri
+        );
     }
 
     private async toggleDirectoryOrOpenFile(hint: string) {


### PR DESCRIPTION
Note that I haven't added the command in package.json on purpose. Adding it there would make an entry in the command palette, adding unnecessary noise, since this command can't be run on its own. We should probably go over the rest of the commands and remove those that doesn't make sense to trigger without specifying a hint.

Closes #15.