### PR TITLE
Make default hintPosition `left`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
                 },
                 "talon-filetree.hintPosition": {
                     "type": "string",
-                    "default": "right",
+                    "default": "left",
                     "enum": [
                         "left",
                         "right"


### PR DESCRIPTION
This makes it so that by default items are displayed like `[ab] some-file.py`. I have been using that for a long time and I think it's easier to parse than the current default.